### PR TITLE
Added undoAll() and redoAll() methods

### DIFF
--- a/Tests/Backbone.Undo.Tests.js
+++ b/Tests/Backbone.Undo.Tests.js
@@ -306,6 +306,29 @@ test("Clearing all actions", function () {
 	deepEqual(model.toJSON(), {"t": 2}, "Clearing actions before redoing was successful");
 })
 
+test("Undoing all actions", function () {
+	var model = new Backbone.Model({
+		"t": 1
+	});
+
+	var UndoManager = new Backbone.UndoManager({
+		track: true,
+		register: model
+	});
+
+	model.set("t", 2);
+	model.set("t", 3);
+	model.set("t", 4);
+
+	UndoManager.undoAll();
+
+	deepEqual(model.toJSON(), {"t": 1}, "Calling undoAll was successful");
+
+	UndoManager.redoAll();
+
+	deepEqual(model.toJSON(), {"t": 4}, "Calling redoAll was successful");
+})
+
 /**
  * Async tests for magic condensation
  */


### PR DESCRIPTION
Hello Oliver,

First of all, thanks for your work, which is very helpful for us.

My team and I have been using your undoManager for our application. We especially need to undo/ redo all the changes that have been tracked by an undo manager.
We cannot rely on magic fusion (which is really clever by the way) since changes can happen at different timings.

I guess we could use the undoTypes system to achieve this goal but it seemed more straight forward to implement the methods _undoAll()_ and _redoAll()_

I also added a test.
What do you think ? Would this feature be welcome in your API ?
