### PR TITLE
resetStack function

### DIFF
--- a/Backbone.Undo.js
+++ b/Backbone.Undo.js
@@ -657,6 +657,16 @@
 			addToStack(this.stack, type, slice(arguments, 1), this.undoTypes);
 		},
 		/**
+		 * This function allow us to clear the stack in case we want to
+		 * remove all the undo/redo available
+		 * @return {undefined}
+		 */
+		resetStack: function () {
+			this.stack = new UndoStack;
+			this.stack.setMaxLength(this.get("maximumStackLength"));
+			this.stack.track = this.get('track');
+		},
+		/**
 		 * Registers one or more objects to track their changes.
 		 * @param {...Object} 	obj 	The object or objects of which changes should be tracked
 		 * @return {undefined}


### PR DESCRIPTION
Sometimes we want to reset the state of the Undo, because we don't want the user to be able to go back. A clean state, or in this case, a clean stack.