### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple Backbone undo-manager for simple apps",
   "homepage": "http://backbone.undojs.com",
   "keywords": "backbone, undo",
-  "license": "MIT license",
+  "license": "MIT",
   "main": "Backbone.Undo.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)