### PR TITLE
Compatability towards lodash 4.0

### DIFF
--- a/Backbone.Undo.js
+++ b/Backbone.Undo.js
@@ -69,7 +69,7 @@
 		if (!_.isArray(keys)) {
 			keys = slice(arguments, 1);
 		}
-		return _.all(keys, function (key) {
+		return _.every(keys, function (key) {
 			return key in obj;
 		});
 	}
@@ -154,7 +154,7 @@
 			// This is where we get a performance boost 
 			// by using the two different ways of storing 
 			// objects.
-			return obj && obj.cid ? this.registeredObjects[obj.cid] : _.contains(this.registeredObjects, obj);
+			return obj && obj.cid ? this.registeredObjects[obj.cid] : _.includes(this.registeredObjects, obj);
 		},
 		/**
 		 * Registers an object in this ObjectRegistry.
@@ -516,7 +516,7 @@
 
 		switch (manipType) {
 			case 0: // add
-				if (hasKeys(fns, "undo", "redo", "on") && _.all(_.pick(fns, "undo", "redo", "on"), _.isFunction)) {
+				if (hasKeys(fns, "undo", "redo", "on") && _.every(_.pick(fns, "undo", "redo", "on"), _.isFunction)) {
 					undoTypesInstance[undoType] = fns;
 				} 
 			break;


### PR DESCRIPTION
lodash dropped support for several obselete aliases. In order to support lodash 4.0 I had to replace:

- _.contains --> _.includes
- _.all --> _.every

Underscore still supports these aliases. This way it is compatible with lodash and underscore.